### PR TITLE
Moved database details to the env file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
     image: postgres
     restart: always
     ports:
-      - 5432:5432
+      - ${DB_PORT}:5432
     environment:
-      POSTGRES_USER: root
-      POSTGRES_PASSWORD: cdmnexus
-      POSTGRES_DB: local
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}


### PR DESCRIPTION
Forgot to keep sensitive database info inside of the .env file. woopsies.