### PR TITLE
Fixed a typo in the regex check for CDM emails.

### DIFF
--- a/src/lib/server/db/schema/users.ts
+++ b/src/lib/server/db/schema/users.ts
@@ -25,7 +25,7 @@ export const users = pgTable(
     ),
     check(
       'check_cdm_email_format',
-      sql`${table.cdmEmail} ~ '^[A-za-z0-9.]+(@cdm.edu.ph)$'`
+      sql`${table.cdmEmail} ~ '^[A-Za-z0-9.]+(@cdm.edu.ph)$'`
     ),
   ]
 );


### PR DESCRIPTION
- Short typo correction in the regex check for CDM email validation.
- Suggested by Github Advanced Security.