### PR TITLE
Fixing the Picsum URL for the auth routes backdrop.

### DIFF
--- a/src/lib/components/auth/Backdrop.svelte
+++ b/src/lib/components/auth/Backdrop.svelte
@@ -4,6 +4,6 @@
 
 <style>
   .bg-image {
-    background-image: url(https://picsum.photos/seed/cdm/1920/1080/?blur=4);
+    background-image: url(https://picsum.photos/seed/cdm/1920/1080?blur=4);
   }
 </style>


### PR DESCRIPTION
- Removes an unnecessary slash on the URL to prevent an additional redirect when loading the auth routes backdrop image. 